### PR TITLE
Add unit for metricName

### DIFF
--- a/vmware_exporter.go
+++ b/vmware_exporter.go
@@ -124,7 +124,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	for _, perfCounterInfo := range e.performanceManager.PerfCounter {
 		groupInfo := perfCounterInfo.GroupInfo.GetElementDescription()
 		nameInfo := perfCounterInfo.NameInfo.GetElementDescription()
-		metricName := fmt.Sprintf("vsphere_%s_%s", snaker.CamelToSnake(groupInfo.Key), strings.Join(strings.Split(snaker.CamelToSnake(nameInfo.Key), "."), "_"))
+		metricName := fmt.Sprintf("vsphere_%s_%s_%s", snaker.CamelToSnake(groupInfo.Key), strings.Join(strings.Split(snaker.CamelToSnake(nameInfo.Key), "."), "_"), snaker.CamelToSnake(unitInfo.Key))
 		labels := []string{"host", "instance", "entity"}
 		desc := prometheus.NewDesc(metricName, nameInfo.Summary, labels, nil)
 		countersInfoMap[int(perfCounterInfo.Key)] = desc


### PR DESCRIPTION
Because the number of metrics is large, it is difficult to understand the unit.